### PR TITLE
🐛 (helm/v2-alpha): Preserve API compatibility in NetworkPolicy fix

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/config/default/kustomization.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/default/kustomization.yaml
@@ -31,7 +31,7 @@ resources:
 - metrics_service.yaml
 # [NETWORK POLICY] Protect the /metrics endpoint and Webhook Server with NetworkPolicy.
 # Only Pod(s) running a namespace labeled with 'metrics: enabled' will be able to gather the metrics.
-# Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhooks: enabled' will
+# Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhook: enabled' will
 # be able to communicate with the Webhook Server.
 #- ../network-policy
 

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/network-policy/allow-webhook-traffic.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/network-policy/allow-webhook-traffic.yaml
@@ -23,5 +23,5 @@ spec:
           matchLabels:
             webhook: enabled # Only from namespaces with this label
       ports:
-        - port: 443
+        - port: 9443
           protocol: TCP

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/network-policy/allow-metrics-traffic.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/network-policy/allow-metrics-traffic.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.networkPolicy.enabled }}
+{{- if and .Values.networkPolicy.enabled .Values.metrics.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/docs/book/src/getting-started/testdata/project/config/default/kustomization.yaml
+++ b/docs/book/src/getting-started/testdata/project/config/default/kustomization.yaml
@@ -29,7 +29,7 @@ resources:
 - metrics_service.yaml
 # [NETWORK POLICY] Protect the /metrics endpoint and Webhook Server with NetworkPolicy.
 # Only Pod(s) running a namespace labeled with 'metrics: enabled' will be able to gather the metrics.
-# Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhooks: enabled' will
+# Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhook: enabled' will
 # be able to communicate with the Webhook Server.
 #- ../network-policy
 

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/network-policy/allow-metrics-traffic.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/network-policy/allow-metrics-traffic.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.networkPolicy.enabled }}
+{{- if and .Values.networkPolicy.enabled .Values.metrics.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/default/kustomization.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/default/kustomization.yaml
@@ -31,7 +31,7 @@ resources:
 - metrics_service.yaml
 # [NETWORK POLICY] Protect the /metrics endpoint and Webhook Server with NetworkPolicy.
 # Only Pod(s) running a namespace labeled with 'metrics: enabled' will be able to gather the metrics.
-# Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhooks: enabled' will
+# Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhook: enabled' will
 # be able to communicate with the Webhook Server.
 #- ../network-policy
 

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/network-policy/allow-webhook-traffic.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/network-policy/allow-webhook-traffic.yaml
@@ -23,5 +23,5 @@ spec:
           matchLabels:
             webhook: enabled # Only from namespaces with this label
       ports:
-        - port: 443
+        - port: 9443
           protocol: TCP

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/network-policy/allow-metrics-traffic.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/network-policy/allow-metrics-traffic.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.networkPolicy.enabled }}
+{{- if and .Values.networkPolicy.enabled .Values.metrics.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/docs/book/src/plugins/available/helm-v2-alpha.md
+++ b/docs/book/src/plugins/available/helm-v2-alpha.md
@@ -283,6 +283,18 @@ Set `networkPolicy.enabled: true` to install NetworkPolicy resources for the man
 
 When the kustomize output includes `NetworkPolicy` resources, the plugin converts them into chart templates and sets `networkPolicy.enabled: true`. When no `NetworkPolicy` resources are present in the kustomize output, the plugin generates default templates for metrics traffic, and also for webhook traffic when webhooks are detected in the provided kustomize input files.
 
+Like the Prometheus `ServiceMonitor`, the NetworkPolicy templates are user-owned: once scaffolded, `kubebuilder edit --plugins helm/v2-alpha` preserves your local edits on regeneration and only overwrites them when you pass `--force`.
+
+The metrics policy is gated on both `networkPolicy.enabled` and `metrics.enabled`; the webhook policy is gated on both `networkPolicy.enabled` and `webhook.enabled`. The policies only allow traffic from namespaces carrying the expected label, so consumers must label the namespaces that need access:
+
+```sh
+# Allow scraping the metrics endpoint from this namespace
+kubectl label namespace <namespace> metrics=enabled
+
+# Allow the webhook server to receive requests from this namespace
+kubectl label namespace <namespace> webhook=enabled
+```
+
 ### Custom labels and annotations
 
 Add custom labels and annotations using `manager.labels`, `manager.annotations`, `manager.pod.labels`, and `manager.pod.annotations`. Duplicate keys from kustomize are filtered automatically.

--- a/docs/book/src/reference/metrics.md
+++ b/docs/book/src/reference/metrics.md
@@ -362,7 +362,7 @@ Uncomment the following line in the `config/default/kustomization.yaml`:
 ```yaml
 # [NETWORK POLICY] Protect the /metrics endpoint and Webhook Server with NetworkPolicy.
 # Only Pod(s) running a namespace labeled with 'metrics: enabled' are able to gather the metrics.
-# Only CR(s) which uses webhooks and applied on namespaces labeled 'webhooks: enabled' are able to work properly.
+# Only CR(s) which uses webhooks and applied on namespaces labeled 'webhook: enabled' are able to work properly.
 #- ../network-policy
 ```
 

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/kustomization.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/kustomization.go
@@ -75,7 +75,7 @@ resources:
 - metrics_service.yaml
 # [NETWORK POLICY] Protect the /metrics endpoint and Webhook Server with NetworkPolicy.
 # Only Pod(s) running a namespace labeled with 'metrics: enabled' will be able to gather the metrics.
-# Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhooks: enabled' will
+# Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhook: enabled' will
 # be able to communicate with the Webhook Server.
 #- ../network-policy
 

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/network-policy/allow-webhook-traffic.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/network-policy/allow-webhook-traffic.go
@@ -67,6 +67,6 @@ spec:
           matchLabels:
             webhook: enabled # Only from namespaces with this label
       ports:
-        - port: 443
+        - port: 9443
           protocol: TCP
 `

--- a/pkg/plugins/optional/helm/v2alpha/edit.go
+++ b/pkg/plugins/optional/helm/v2alpha/edit.go
@@ -82,8 +82,8 @@ when the kustomize output does not provide them. When enabled, adds Helm helpers
 
 **NOTE**: Chart.yaml is never overwritten (contains user-managed version info).
 Without --force, the plugin also preserves values.yaml, NOTES.txt, _helpers.tpl, .helmignore,
-.github/workflows/test-chart.yml, network-policy/allow-metrics-traffic.yaml, and
-network-policy/allow-webhook-traffic.yaml.
+.github/workflows/test-chart.yml, and the user-owned templates under network-policy/ and
+prometheus/ (the NetworkPolicies and the Prometheus ServiceMonitor).
 All other template files in templates/ are always regenerated to match your current
 kustomize output. Use --force to regenerate all files except Chart.yaml.
 

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/chart_scaffolder.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/chart_scaffolder.go
@@ -116,6 +116,7 @@ func (s *ChartScaffolder) PrepareTemplates(_ machinery.Filesystem) ([]machinery.
 		extraction.Metadata.ManagerNamespace,
 		s.config.OutputDir,
 		extraction.Features.RoleNamespaces,
+		s.config.Force,
 	)
 
 	// Get builders for kustomize-derived chart templates

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/chart_scaffolder.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/chart_scaffolder.go
@@ -109,7 +109,7 @@ func (s *ChartScaffolder) PrepareTemplates(_ machinery.Filesystem) ([]machinery.
 		return nil, fmt.Errorf("unable to generate the chart: %w", err)
 	}
 
-	chartConverter := kustomize.NewChartConverter(
+	chartConverter := kustomize.NewChartConverterWithForce(
 		resources,
 		extraction.Metadata.DetectedPrefix,
 		extraction.Metadata.ChartName,

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/chart_scaffolder_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/chart_scaffolder_test.go
@@ -45,7 +45,8 @@ var _ = Describe("ChartScaffolder", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			rendered := string(content)
-			Expect(rendered).To(ContainSubstring("{{- if .Values.networkPolicy.enabled }}"))
+			Expect(rendered).To(ContainSubstring(
+				"{{- if and .Values.networkPolicy.enabled .Values.metrics.enabled }}"))
 			Expect(rendered).To(ContainSubstring("kind: NetworkPolicy"))
 			Expect(rendered).To(ContainSubstring(
 				`name: {{ include "test-project.resourceName" (dict "suffix" "allow-metrics-traffic" "context" $) }}`))
@@ -100,7 +101,8 @@ var _ = Describe("ChartScaffolder", func() {
 			content, err := afero.ReadFile(fs, "dist/chart/templates/network-policy/allow-metrics-traffic.yaml")
 			Expect(err).NotTo(HaveOccurred())
 			rendered := string(content)
-			Expect(rendered).To(ContainSubstring("{{- if .Values.networkPolicy.enabled }}"))
+			Expect(rendered).To(ContainSubstring(
+				"{{- if and .Values.networkPolicy.enabled .Values.metrics.enabled }}"))
 			Expect(rendered).To(ContainSubstring("metrics: enabled"))
 			Expect(rendered).To(ContainSubstring("port: {{ .Values.metrics.port }}"))
 
@@ -110,6 +112,54 @@ var _ = Describe("ChartScaffolder", func() {
 			values, err := afero.ReadFile(fs, "dist/chart/values.yaml")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(values)).To(ContainSubstring("networkPolicy:\n  enabled: true"))
+		})
+
+		It("should produce only the metrics policy when kustomize output has no webhook", func() {
+			manifestsPath := filepath.Join(GinkgoT().TempDir(), "install.yaml")
+			Expect(os.WriteFile(
+				manifestsPath,
+				[]byte(manifestsWithMetricsNetworkPolicyNoWebhooks),
+				0o600,
+			)).To(Succeed())
+
+			fs := executeChartScaffolder(manifestsPath)
+
+			content, err := afero.ReadFile(fs, "dist/chart/templates/network-policy/allow-metrics-traffic.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(content)).To(ContainSubstring(
+				"{{- if and .Values.networkPolicy.enabled .Values.metrics.enabled }}"))
+			Expect(string(content)).To(ContainSubstring("port: {{ .Values.metrics.port }}"))
+
+			_, err = afero.ReadFile(fs, "dist/chart/templates/network-policy/allow-webhook-traffic.yaml")
+			Expect(err).To(HaveOccurred())
+
+			values, err := afero.ReadFile(fs, "dist/chart/values.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(values)).To(ContainSubstring("networkPolicy:\n  enabled: true"))
+		})
+
+		It("should preserve an egress NetworkPolicy from kustomize output", func() {
+			manifestsPath := filepath.Join(GinkgoT().TempDir(), "install.yaml")
+			Expect(os.WriteFile(
+				manifestsPath,
+				[]byte(manifestsWithEgressNetworkPolicy),
+				0o600,
+			)).To(Succeed())
+
+			fs := executeChartScaffolder(manifestsPath)
+
+			content, err := afero.ReadFile(fs, "dist/chart/templates/network-policy/allow-egress-dns.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			rendered := string(content)
+			// Custom policies are gated on networkPolicy.enabled only, regardless of direction.
+			Expect(rendered).To(ContainSubstring("{{- if .Values.networkPolicy.enabled }}"))
+			Expect(rendered).NotTo(ContainSubstring(".Values.metrics.enabled"))
+			// Egress ports target other services and must not be rewritten to a manager port.
+			Expect(rendered).To(ContainSubstring("policyTypes:"))
+			Expect(rendered).To(ContainSubstring("- Egress"))
+			Expect(rendered).To(ContainSubstring("port: 53"))
+			Expect(rendered).NotTo(ContainSubstring(".Values.metrics.port"))
+			Expect(rendered).NotTo(ContainSubstring(".Values.webhook.port"))
 		})
 
 		It("should place all NetworkPolicies from kustomize output in the network-policy directory", func() {
@@ -127,7 +177,8 @@ var _ = Describe("ChartScaffolder", func() {
 				"dist/chart/templates/network-policy/allow-metrics-traffic.yaml",
 			)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(string(metricsPolicy)).To(ContainSubstring("{{- if .Values.networkPolicy.enabled }}"))
+			Expect(string(metricsPolicy)).To(ContainSubstring(
+				"{{- if and .Values.networkPolicy.enabled .Values.metrics.enabled }}"))
 			Expect(string(metricsPolicy)).To(ContainSubstring("metrics: enabled"))
 			Expect(string(metricsPolicy)).To(ContainSubstring("port: {{ .Values.metrics.port }}"))
 
@@ -352,6 +403,50 @@ metadata:
 webhooks: []
 `
 
+const manifestsWithEgressNetworkPolicy = manifestsWithoutNetworkPolicy + `---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-project-allow-egress-dns
+  namespace: test-system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+      app.kubernetes.io/name: test-project
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+      - namespaceSelector: {}
+      ports:
+        - port: 53
+          protocol: UDP
+`
+
+const manifestsWithMetricsNetworkPolicyNoWebhooks = manifestsWithoutNetworkPolicy + `---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-project-allow-metrics-traffic
+  namespace: test-system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+      app.kubernetes.io/name: test-project
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            metrics: enabled
+      ports:
+        - port: 8443
+          protocol: TCP
+`
+
 const manifestsWithMultipleNetworkPolicies = manifestsWithoutNetworkPolicy + `---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -413,7 +508,7 @@ spec:
           matchLabels:
             webhook: enabled
       ports:
-        - port: 443
+        - port: 9443
           protocol: TCP
 `
 

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/deployment_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/deployment_test.go
@@ -32,6 +32,10 @@ const (
 	keySecret       = "secret"
 	keyVolumeMounts = "volumeMounts"
 	keyMountPath    = "mountPath"
+	keyAPIVersion   = "apiVersion"
+	keyKind         = "kind"
+	keyMetadata     = "metadata"
+	keySpec         = "spec"
 
 	valAppsV1            = "apps/v1"
 	valDeployment        = "Deployment"
@@ -75,20 +79,20 @@ func makeDeployment(opts deploymentOpts) *unstructured.Unstructured {
 	if opts.volumes != nil {
 		podSpec["volumes"] = opts.volumes
 	}
-	template := map[string]any{"spec": podSpec}
+	template := map[string]any{keySpec: podSpec}
 	if opts.annotations != nil {
 		annotations := make(map[string]any, len(opts.annotations))
 		for k, v := range opts.annotations {
 			annotations[k] = v
 		}
-		template["metadata"] = map[string]any{"annotations": annotations}
+		template[keyMetadata] = map[string]any{"annotations": annotations}
 	}
 	return &unstructured.Unstructured{
 		Object: map[string]any{
-			"apiVersion": valAppsV1,
-			"kind":       valDeployment,
-			"metadata":   map[string]any{keyName: valTestDeploy},
-			"spec": map[string]any{
+			keyAPIVersion: valAppsV1,
+			keyKind:       valDeployment,
+			keyMetadata:   map[string]any{keyName: valTestDeploy},
+			keySpec: map[string]any{
 				"template": template,
 			},
 		},
@@ -124,7 +128,7 @@ var _ = Describe("DeploymentExtractor", func() {
 		})
 
 		It("should preserve scale-to-zero", func() {
-			deployment.Object["spec"].(map[string]any)[keyReplicas] = int64(0)
+			deployment.Object[keySpec].(map[string]any)[keyReplicas] = int64(0)
 			result, err := extractor.ExtractDeploymentConfig(deployment)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Manager.Replicas).NotTo(BeNil())
@@ -132,7 +136,7 @@ var _ = Describe("DeploymentExtractor", func() {
 		})
 
 		It("should extract replicas value", func() {
-			deployment.Object["spec"].(map[string]any)[keyReplicas] = int64(3)
+			deployment.Object[keySpec].(map[string]any)[keyReplicas] = int64(3)
 			result, err := extractor.ExtractDeploymentConfig(deployment)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Manager.Replicas).NotTo(BeNil())
@@ -447,7 +451,7 @@ var _ = Describe("DeploymentExtractor", func() {
 						},
 						"ports": []any{
 							map[string]any{
-								"name":          "webhook-server",
+								keyName:         "webhook-server",
 								"containerPort": int64(9443),
 							},
 						},

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/features.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/features.go
@@ -27,20 +27,22 @@ type FeaturesExtractor struct{}
 
 // FeatureSet represents detected features in the resources.
 // It includes flags for CRDs, webhooks, metrics, Prometheus, cert-manager,
-// NetworkPolicies, and cluster-scoped RBAC.
+// NetworkPolicies, NetworkPolicy traffic paths, and cluster-scoped RBAC.
 // It also includes port configurations and multi-namespace RBAC mappings.
 type FeatureSet struct {
-	HasCRDs              bool
-	HasWebhooks          bool
-	HasMetrics           bool
-	HasPrometheus        bool
-	HasCertManager       bool
-	HasNetworkPolicy     bool
-	HasClusterScopedRBAC bool
-	WebhookPort          int
-	MetricsPort          int
-	HealthProbePort      int
-	RoleNamespaces       map[string]string
+	HasCRDs                 bool
+	HasWebhooks             bool
+	HasMetrics              bool
+	HasPrometheus           bool
+	HasCertManager          bool
+	HasNetworkPolicy        bool
+	HasMetricsNetworkPolicy bool
+	HasWebhookNetworkPolicy bool
+	HasClusterScopedRBAC    bool
+	WebhookPort             int
+	MetricsPort             int
+	HealthProbePort         int
+	RoleNamespaces          map[string]string
 }
 
 // DetectFeatures detects features from parsed resources.
@@ -61,6 +63,15 @@ func (f *FeaturesExtractor) DetectFeatures(resources *ResourceSet, namePrefix, m
 
 	features.HasPrometheus = len(resources.ServiceMonitors) > 0
 	features.HasNetworkPolicy = len(resources.NetworkPolicies) > 0
+	for _, policy := range resources.NetworkPolicies {
+		name := policy.GetName()
+		if strings.HasSuffix(name, "allow-metrics-traffic") {
+			features.HasMetricsNetworkPolicy = true
+		}
+		if strings.HasSuffix(name, "allow-webhook-traffic") {
+			features.HasWebhookNetworkPolicy = true
+		}
+	}
 
 	for _, svc := range resources.Services {
 		name := svc.GetName()

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/features.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/features.go
@@ -27,22 +27,20 @@ type FeaturesExtractor struct{}
 
 // FeatureSet represents detected features in the resources.
 // It includes flags for CRDs, webhooks, metrics, Prometheus, cert-manager,
-// NetworkPolicies, NetworkPolicy traffic paths, and cluster-scoped RBAC.
+// NetworkPolicies, and cluster-scoped RBAC.
 // It also includes port configurations and multi-namespace RBAC mappings.
 type FeatureSet struct {
-	HasCRDs                 bool
-	HasWebhooks             bool
-	HasMetrics              bool
-	HasPrometheus           bool
-	HasCertManager          bool
-	HasNetworkPolicy        bool
-	HasMetricsNetworkPolicy bool
-	HasWebhookNetworkPolicy bool
-	HasClusterScopedRBAC    bool
-	WebhookPort             int
-	MetricsPort             int
-	HealthProbePort         int
-	RoleNamespaces          map[string]string
+	HasCRDs              bool
+	HasWebhooks          bool
+	HasMetrics           bool
+	HasPrometheus        bool
+	HasCertManager       bool
+	HasNetworkPolicy     bool
+	HasClusterScopedRBAC bool
+	WebhookPort          int
+	MetricsPort          int
+	HealthProbePort      int
+	RoleNamespaces       map[string]string
 }
 
 // DetectFeatures detects features from parsed resources.
@@ -63,15 +61,6 @@ func (f *FeaturesExtractor) DetectFeatures(resources *ResourceSet, namePrefix, m
 
 	features.HasPrometheus = len(resources.ServiceMonitors) > 0
 	features.HasNetworkPolicy = len(resources.NetworkPolicies) > 0
-	for _, policy := range resources.NetworkPolicies {
-		name := policy.GetName()
-		if strings.HasSuffix(name, "allow-metrics-traffic") {
-			features.HasMetricsNetworkPolicy = true
-		}
-		if strings.HasSuffix(name, "allow-webhook-traffic") {
-			features.HasWebhookNetworkPolicy = true
-		}
-	}
 
 	for _, svc := range resources.Services {
 		name := svc.GetName()
@@ -93,12 +82,14 @@ func (f *FeaturesExtractor) DetectFeatures(resources *ResourceSet, namePrefix, m
 			}
 		}
 
-		// Only extract from service if we didn't find it in deployment
+		// Only extract from service if we didn't find it in deployment.
+		// The webhook server listens on the Service targetPort (the pod port), not the
+		// exposed Service port (443), so the webhook port must come from targetPort.
 		if !webhookPortFromDeployment {
 			for _, svc := range resources.Services {
 				name := svc.GetName()
 				if strings.HasSuffix(name, "-webhook-service") {
-					if port := extractPortFromService(svc); port > 0 {
+					if port := extractTargetPortFromService(svc); port > 0 {
 						features.WebhookPort = port
 					}
 					break
@@ -149,21 +140,43 @@ func (f *FeaturesExtractor) DetectFeatures(resources *ResourceSet, namePrefix, m
 	return features
 }
 
-// extractPortFromService extracts the port number from a service.
-func extractPortFromService(svc *unstructured.Unstructured) int {
+// firstServicePort returns the first entry of a service's spec.ports, or false when absent.
+func firstServicePort(svc *unstructured.Unstructured) (map[string]any, bool) {
 	ports, found, err := unstructured.NestedFieldNoCopy(svc.Object, "spec", "ports")
 	if !found || err != nil {
-		return 0
+		return nil, false
 	}
 
 	portsList, ok := ports.([]any)
 	if !ok || len(portsList) == 0 {
-		return 0
+		return nil, false
 	}
 
 	firstPort, ok := portsList[0].(map[string]any)
+	return firstPort, ok
+}
+
+// extractPortFromService extracts the exposed port of a service's first port.
+func extractPortFromService(svc *unstructured.Unstructured) int {
+	firstPort, ok := firstServicePort(svc)
 	if !ok {
 		return 0
+	}
+
+	port, _ := toInt(firstPort["port"])
+	return port
+}
+
+// extractTargetPortFromService extracts the numeric targetPort of a service's first port,
+// falling back to the exposed port when targetPort is absent or non-numeric (a named port).
+func extractTargetPortFromService(svc *unstructured.Unstructured) int {
+	firstPort, ok := firstServicePort(svc)
+	if !ok {
+		return 0
+	}
+
+	if targetPort, ok := toInt(firstPort["targetPort"]); ok && targetPort > 0 {
+		return targetPort
 	}
 
 	port, _ := toInt(firstPort["port"])

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/features_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/features_test.go
@@ -143,4 +143,62 @@ var _ = Describe("FeaturesExtractor", func() {
 			Expect(features.HealthProbePort).To(Equal(9091))
 		})
 	})
+
+	Describe("DetectFeatures webhook port", func() {
+		It("uses the webhook Service targetPort, not the exposed port, when the deployment omits it", func() {
+			deployment := makeDeployment(deploymentOpts{
+				containers: []map[string]any{{keyName: valManager, keyImage: valControllerImage}},
+			})
+
+			features := featuresExtractor.DetectFeatures(&ResourceSet{
+				Deployment:            deployment,
+				Services:              []*unstructured.Unstructured{newWebhookService(443, 9443)},
+				WebhookConfigurations: []*unstructured.Unstructured{newValidatingWebhookConfig()},
+			}, "test-project", "test-system")
+
+			Expect(features.WebhookPort).To(Equal(9443))
+		})
+
+		It("prefers the webhook port declared on the manager container args", func() {
+			deployment := makeDeployment(deploymentOpts{
+				containers: []map[string]any{{
+					keyName:  valManager,
+					keyImage: valControllerImage,
+					keyArgs:  []any{"--webhook-port=9444"},
+				}},
+			})
+
+			features := featuresExtractor.DetectFeatures(&ResourceSet{
+				Deployment:            deployment,
+				Services:              []*unstructured.Unstructured{newWebhookService(443, 9443)},
+				WebhookConfigurations: []*unstructured.Unstructured{newValidatingWebhookConfig()},
+			}, "test-project", "test-system")
+
+			Expect(features.WebhookPort).To(Equal(9444))
+		})
+	})
 })
+
+// newValidatingWebhookConfig builds a minimal ValidatingWebhookConfiguration for feature detection.
+func newValidatingWebhookConfig() *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		keyAPIVersion: "admissionregistration.k8s.io/v1",
+		keyKind:       "ValidatingWebhookConfiguration",
+		keyMetadata:   map[string]any{keyName: "test-project-validating-webhook-configuration"},
+	}}
+}
+
+// newWebhookService builds a webhook Service whose first port exposes port and forwards to targetPort.
+func newWebhookService(port, targetPort int64) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		keyAPIVersion: "v1",
+		keyKind:       "Service",
+		keyMetadata:   map[string]any{keyName: "test-project-webhook-service"},
+		keySpec: map[string]any{
+			"ports": []any{map[string]any{
+				"port":       port,
+				"targetPort": targetPort,
+			}},
+		},
+	}}
+}

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_converter.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_converter.go
@@ -18,6 +18,7 @@ package kustomize
 
 import (
 	"slices"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -33,6 +34,7 @@ type ChartConverter struct {
 	detectedPrefix string
 	chartName      string
 	outputDir      string
+	force          bool
 
 	categorizer *ResourceCategorizer
 	templater   *templater.Templater
@@ -42,7 +44,7 @@ type ChartConverter struct {
 // NewChartConverter creates a new chart converter.
 func NewChartConverter(
 	resources *ParsedResources, detectedPrefix, chartName, managerNamespace, outputDir string,
-	roleNamespaces map[string]string,
+	roleNamespaces map[string]string, force bool,
 ) *ChartConverter {
 	categorizer := NewResourceCategorizer(resources)
 	t := templater.NewTemplater(detectedPrefix, chartName, managerNamespace, roleNamespaces)
@@ -53,6 +55,7 @@ func NewChartConverter(
 		detectedPrefix: detectedPrefix,
 		chartName:      chartName,
 		outputDir:      outputDir,
+		force:          force,
 		categorizer:    categorizer,
 		templater:      t,
 		generator:      chartGenerator,
@@ -82,10 +85,26 @@ func (c *ChartConverter) GetChartBuilders() []machinery.Builder {
 			RelativePath: filename,
 			Content:      chartFiles.TemplateFiles[filename],
 			OutputDir:    c.outputDir,
+			Force:        c.force,
 		})
 	}
 
 	return builders
+}
+
+// userOwnedTemplateDirs are chart template subdirectories the plugin scaffolds once and then
+// leaves to the user. Files under them (NetworkPolicies and the Prometheus ServiceMonitor) keep
+// local edits on regeneration unless --force is set, matching their fallback templates.
+var userOwnedTemplateDirs = []string{"network-policy/", "prometheus/"}
+
+// isUserOwnedTemplate reports whether a chart-relative template path is user-owned.
+func isUserOwnedTemplate(relativePath string) bool {
+	for _, dir := range userOwnedTemplateDirs {
+		if strings.HasPrefix(relativePath, dir) {
+			return true
+		}
+	}
+	return false
 }
 
 // dedupeResources removes duplicate resources to prevent rendering the same resource multiple times.

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_converter.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_converter.go
@@ -44,6 +44,16 @@ type ChartConverter struct {
 // NewChartConverter creates a new chart converter.
 func NewChartConverter(
 	resources *ParsedResources, detectedPrefix, chartName, managerNamespace, outputDir string,
+	roleNamespaces map[string]string,
+) *ChartConverter {
+	return NewChartConverterWithForce(
+		resources, detectedPrefix, chartName, managerNamespace, outputDir, roleNamespaces, false,
+	)
+}
+
+// NewChartConverterWithForce creates a new chart converter with force overwrite behavior.
+func NewChartConverterWithForce(
+	resources *ParsedResources, detectedPrefix, chartName, managerNamespace, outputDir string,
 	roleNamespaces map[string]string, force bool,
 ) *ChartConverter {
 	categorizer := NewResourceCategorizer(resources)

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_converter_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_converter_test.go
@@ -18,6 +18,7 @@ package kustomize
 
 import (
 	"path/filepath"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -87,7 +88,7 @@ var _ = Describe("ChartConverter", func() {
 
 		// Create converter
 		converter = NewChartConverter(
-			resources, testProjectName, testProjectName, testNamespaceTestSystem, "dist", make(map[string]string),
+			resources, testProjectName, testProjectName, testNamespaceTestSystem, "dist", make(map[string]string), false,
 		)
 	})
 
@@ -158,6 +159,60 @@ var _ = Describe("ChartConverter", func() {
 			files, err := afero.ReadDir(fs.FS, metricsDir)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(files).To(HaveLen(1), "expected only one metrics service file after deduplication")
+		})
+	})
+
+	Context("user-owned templates (force behavior)", func() {
+		builderFor := func(builders []machinery.Builder, dir string) *DynamicTemplate {
+			for _, b := range builders {
+				if dt, ok := b.(*DynamicTemplate); ok && strings.HasPrefix(dt.RelativePath, dir) {
+					return dt
+				}
+			}
+			return nil
+		}
+
+		addNetworkPolicyAndServiceMonitor := func() {
+			networkPolicy := &unstructured.Unstructured{}
+			networkPolicy.SetAPIVersion("networking.k8s.io/v1")
+			networkPolicy.SetKind("NetworkPolicy")
+			networkPolicy.SetName("test-project-allow-metrics-traffic")
+			resources.NetworkPolicies = []*unstructured.Unstructured{networkPolicy}
+
+			serviceMonitor := &unstructured.Unstructured{}
+			serviceMonitor.SetAPIVersion("monitoring.coreos.com/v1")
+			serviceMonitor.SetKind("ServiceMonitor")
+			serviceMonitor.SetName("test-project-controller-manager-metrics-monitor")
+			resources.ServiceMonitors = []*unstructured.Unstructured{serviceMonitor}
+		}
+
+		ifExistsAction := func(builder *DynamicTemplate) machinery.IfExistsAction {
+			Expect(builder).NotTo(BeNil())
+			Expect(builder.SetTemplateDefaults()).To(Succeed())
+			return builder.IfExistsAction
+		}
+
+		It("preserves NetworkPolicy and ServiceMonitor, and always regenerates the manager", func() {
+			addNetworkPolicyAndServiceMonitor()
+
+			builders := converter.GetChartBuilders()
+
+			Expect(ifExistsAction(builderFor(builders, "network-policy/"))).To(Equal(machinery.SkipFile))
+			Expect(ifExistsAction(builderFor(builders, "prometheus/"))).To(Equal(machinery.SkipFile))
+			Expect(ifExistsAction(builderFor(builders, "manager/"))).To(Equal(machinery.OverwriteFile))
+		})
+
+		It("overwrites the user-owned templates when force is set", func() {
+			addNetworkPolicyAndServiceMonitor()
+
+			forced := NewChartConverter(
+				resources, testProjectName, testProjectName, testNamespaceTestSystem, "dist",
+				make(map[string]string), true,
+			)
+			builders := forced.GetChartBuilders()
+
+			Expect(ifExistsAction(builderFor(builders, "network-policy/"))).To(Equal(machinery.OverwriteFile))
+			Expect(ifExistsAction(builderFor(builders, "prometheus/"))).To(Equal(machinery.OverwriteFile))
 		})
 	})
 

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_converter_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_converter_test.go
@@ -88,7 +88,7 @@ var _ = Describe("ChartConverter", func() {
 
 		// Create converter
 		converter = NewChartConverter(
-			resources, testProjectName, testProjectName, testNamespaceTestSystem, "dist", make(map[string]string), false,
+			resources, testProjectName, testProjectName, testNamespaceTestSystem, "dist", make(map[string]string),
 		)
 	})
 
@@ -205,7 +205,7 @@ var _ = Describe("ChartConverter", func() {
 		It("overwrites the user-owned templates when force is set", func() {
 			addNetworkPolicyAndServiceMonitor()
 
-			forced := NewChartConverter(
+			forced := NewChartConverterWithForce(
 				resources, testProjectName, testProjectName, testNamespaceTestSystem, "dist",
 				make(map[string]string), true,
 			)

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/dynamic_template.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/dynamic_template.go
@@ -37,6 +37,8 @@ type DynamicTemplate struct {
 	Content string
 	// OutputDir is the base output directory (e.g., "dist")
 	OutputDir string
+	// Force allows overwriting user-owned files (e.g. NetworkPolicies) on regeneration.
+	Force bool
 }
 
 // SetTemplateDefaults implements machinery.Template
@@ -62,8 +64,14 @@ func (f *DynamicTemplate) SetTemplateDefaults() error {
 	// This prevents machinery from trying to execute Helm templates as Go templates
 	f.SetDelim("<%", "%>")
 
-	// Always overwrite - these are generated files that should match current kustomize output
-	f.IfExistsAction = machinery.OverwriteFile
+	// Most kustomize-derived files always regenerate to match current kustomize output.
+	// User-owned files (NetworkPolicies, the Prometheus ServiceMonitor) are preserved unless
+	// Force is set, so local edits survive a regeneration.
+	if isUserOwnedTemplate(f.RelativePath) && !f.Force {
+		f.IfExistsAction = machinery.SkipFile
+	} else {
+		f.IfExistsAction = machinery.OverwriteFile
+	}
 
 	return nil
 }

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/conditionals.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/conditionals.go
@@ -48,13 +48,20 @@ func AddConditionalWrappers(yamlContent string, resource *unstructured.Unstructu
 		// CRITICAL: newline before {{- end }} prevents whitespace chomping from eating content
 		return fmt.Sprintf("{{- if .Values.prometheus.enabled }}\n%s\n{{- end }}", yamlContent)
 	case kind == common.KindNetworkPolicy && apiVersion == common.APIVersionNetworking:
-		if strings.HasSuffix(name, "allow-webhook-traffic") {
+		switch {
+		case strings.HasSuffix(name, "allow-webhook-traffic"):
 			return fmt.Sprintf(
 				"{{- if and .Values.networkPolicy.enabled .Values.webhook.enabled }}\n%s\n{{- end }}",
 				yamlContent,
 			)
+		case strings.HasSuffix(name, "allow-metrics-traffic"):
+			return fmt.Sprintf(
+				"{{- if and .Values.networkPolicy.enabled .Values.metrics.enabled }}\n%s\n{{- end }}",
+				yamlContent,
+			)
+		default:
+			return fmt.Sprintf("{{- if .Values.networkPolicy.enabled }}\n%s\n{{- end }}", yamlContent)
 		}
-		return fmt.Sprintf("{{- if .Values.networkPolicy.enabled }}\n%s\n{{- end }}", yamlContent)
 	case kind == common.KindServiceAccount, kind == common.KindRole, kind == common.KindClusterRole,
 		kind == common.KindRoleBinding, kind == common.KindClusterRoleBinding:
 		return HandleRBACConditionalWrappers(yamlContent, kind, name)

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/conditionals_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/conditionals_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package appliers
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func networkPolicy(name string) *unstructured.Unstructured {
+	np := &unstructured.Unstructured{}
+	np.SetAPIVersion("networking.k8s.io/v1")
+	np.SetKind("NetworkPolicy")
+	np.SetName(name)
+	return np
+}
+
+var _ = Describe("AddConditionalWrappers", func() {
+	It("gates the metrics policy on both networkPolicy.enabled and metrics.enabled", func() {
+		result := AddConditionalWrappers("kind: NetworkPolicy\n", networkPolicy("test-project-allow-metrics-traffic"))
+
+		Expect(result).To(ContainSubstring(
+			"{{- if and .Values.networkPolicy.enabled .Values.metrics.enabled }}"))
+		Expect(result).To(ContainSubstring("{{- end }}"))
+	})
+
+	It("gates the webhook policy on both networkPolicy.enabled and webhook.enabled", func() {
+		result := AddConditionalWrappers("kind: NetworkPolicy\n", networkPolicy("test-project-allow-webhook-traffic"))
+
+		Expect(result).To(ContainSubstring(
+			"{{- if and .Values.networkPolicy.enabled .Values.webhook.enabled }}"))
+		Expect(result).To(ContainSubstring("{{- end }}"))
+	})
+
+	It("gates a custom policy on networkPolicy.enabled only", func() {
+		result := AddConditionalWrappers("kind: NetworkPolicy\n", networkPolicy("test-project-allow-dns-traffic"))
+
+		Expect(result).To(ContainSubstring("{{- if .Values.networkPolicy.enabled }}"))
+		Expect(result).NotTo(ContainSubstring(".Values.metrics.enabled"))
+		Expect(result).NotTo(ContainSubstring(".Values.webhook.enabled"))
+	})
+
+	It("does not wrap a NetworkPolicy served by a non-standard apiVersion", func() {
+		np := networkPolicy("custom-policy")
+		np.SetAPIVersion("acme.io/v1")
+
+		result := AddConditionalWrappers("kind: NetworkPolicy\n", np)
+
+		Expect(result).NotTo(ContainSubstring(".Values.networkPolicy.enabled"))
+	})
+})

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/ports.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/ports.go
@@ -50,9 +50,7 @@ func TemplatePorts(yamlContent string, resource *unstructured.Unstructured) stri
 	// Template webhook ports
 	if isWebhook {
 		if resourceKind == common.KindNetworkPolicy {
-			yamlContent = regexp.MustCompile(`(\s*)port:\s*\d+`).
-				ReplaceAllString(yamlContent, "${1}port: {{ .Values.webhook.port }}")
-			return yamlContent
+			return templateNetworkPolicyIngressPort(yamlContent, "{{ .Values.webhook.port }}")
 		}
 
 		// Replace containerPort for webhook-server with template (matches any numeric port)
@@ -68,13 +66,13 @@ func TemplatePorts(yamlContent string, resource *unstructured.Unstructured) stri
 
 	// Template metrics ports
 	if isMetrics {
+		if resourceKind == common.KindNetworkPolicy {
+			return templateNetworkPolicyIngressPort(yamlContent, "{{ .Values.metrics.port }}")
+		}
+
 		// Replace port with metrics.port template (matches any numeric port)
 		yamlContent = regexp.MustCompile(`(\s*)port:\s*\d+`).
 			ReplaceAllString(yamlContent, "${1}port: {{ .Values.metrics.port }}")
-
-		if resourceKind == common.KindNetworkPolicy {
-			return yamlContent
-		}
 
 		// Replace targetPort with metrics.port template (matches any numeric port)
 		yamlContent = regexp.MustCompile(`(\s*)targetPort:\s*\d+`).
@@ -103,6 +101,26 @@ func TemplatePorts(yamlContent string, resource *unstructured.Unstructured) stri
 	}
 
 	return yamlContent
+}
+
+// templateNetworkPolicyIngressPort rewrites the port only inside the NetworkPolicy's
+// ingress rule. Ports under an egress rule target other services and must be left as-is,
+// and scoping to ingress also avoids rewriting every port when a policy declares several.
+func templateNetworkPolicyIngressPort(yamlContent, portTemplate string) string {
+	portRe := regexp.MustCompile(`(\s*)port:\s*\d+`)
+	lines := strings.Split(yamlContent, "\n")
+	inIngress := false
+	for i, line := range lines {
+		switch trimmed := strings.TrimSpace(line); {
+		case strings.HasPrefix(trimmed, "ingress:"):
+			inIngress = true
+		case strings.HasPrefix(trimmed, "egress:"):
+			inIngress = false
+		case inIngress:
+			lines[i] = portRe.ReplaceAllString(line, "${1}port: "+portTemplate)
+		}
+	}
+	return strings.Join(lines, "\n")
 }
 
 // templateHealthProbePort templates the manager health probe port so it can be

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/ports_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/ports_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package appliers
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("TemplatePorts NetworkPolicy", func() {
+	const metricsPolicy = `spec:
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            metrics: enabled
+      ports:
+        - port: 8443
+          protocol: TCP
+`
+
+	It("templates the metrics policy ingress port", func() {
+		result := TemplatePorts(metricsPolicy, networkPolicy("test-project-allow-metrics-traffic"))
+
+		Expect(result).To(ContainSubstring("port: {{ .Values.metrics.port }}"))
+		Expect(result).NotTo(ContainSubstring("port: 8443"))
+	})
+
+	It("templates the webhook policy ingress port", func() {
+		webhookPolicy := `spec:
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            webhook: enabled
+      ports:
+        - port: 9443
+          protocol: TCP
+`
+		result := TemplatePorts(webhookPolicy, networkPolicy("test-project-allow-webhook-traffic"))
+
+		Expect(result).To(ContainSubstring("port: {{ .Values.webhook.port }}"))
+		Expect(result).NotTo(ContainSubstring("port: 9443"))
+	})
+
+	It("leaves a custom policy's ports untouched", func() {
+		dnsPolicy := `spec:
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: 5353
+          protocol: UDP
+`
+		result := TemplatePorts(dnsPolicy, networkPolicy("test-project-allow-dns-traffic"))
+
+		Expect(result).To(ContainSubstring("port: 5353"))
+		Expect(result).NotTo(ContainSubstring(".Values."))
+	})
+
+	It("templates only the ingress port and preserves egress ports of a metrics policy", func() {
+		mixedPolicy := `spec:
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - ports:
+        - port: 8443
+          protocol: TCP
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+`
+		result := TemplatePorts(mixedPolicy, networkPolicy("test-project-allow-metrics-traffic"))
+
+		Expect(result).To(ContainSubstring("port: {{ .Values.metrics.port }}"))
+		Expect(result).NotTo(ContainSubstring("port: 8443"))
+		Expect(result).To(ContainSubstring("port: 53"), "egress port must not be rewritten")
+	})
+})

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
@@ -584,7 +584,8 @@ spec:
 
 			result := templater.ApplyHelmSubstitutions(content, networkPolicyResource)
 
-			Expect(result).To(ContainSubstring("{{- if .Values.networkPolicy.enabled }}"))
+			Expect(result).To(ContainSubstring(
+				"{{- if and .Values.networkPolicy.enabled .Values.metrics.enabled }}"))
 			Expect(result).To(ContainSubstring("{{- end }}"))
 		})
 
@@ -2704,13 +2705,13 @@ metadata:
 spec:
   ingress:
   - ports:
-    - port: 443
+    - port: 9443
       protocol: TCP`
 
 			result := templater.templatePorts(content, networkPolicy)
 
 			Expect(result).To(ContainSubstring("port: {{ .Values.webhook.port }}"))
-			Expect(result).NotTo(ContainSubstring("port: 443"))
+			Expect(result).NotTo(ContainSubstring("port: 9443"))
 		})
 
 		It("should not template custom NetworkPolicy ports", func() {

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/networkpolicy.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/networkpolicy.go
@@ -69,7 +69,8 @@ func (f *NetworkPolicy) SetTemplateDefaults() error {
 	return nil
 }
 
-const networkPolicyTemplate = `{{` + "`" + `{{- if .Values.networkPolicy.enabled }}` + "`" + `}}
+const networkPolicyTemplate = `{{` + "`" +
+	`{{- if and .Values.networkPolicy.enabled .Values.metrics.enabled }}` + "`" + `}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/networkpolicy_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/networkpolicy_test.go
@@ -69,7 +69,8 @@ var _ = Describe("NetworkPolicy", func() {
 			err := networkPolicy.SetTemplateDefaults()
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(networkPolicy.TemplateBody).To(ContainSubstring("{{`{{- if .Values.networkPolicy.enabled }}`}}"))
+			Expect(networkPolicy.TemplateBody).To(ContainSubstring(
+				"{{`{{- if and .Values.networkPolicy.enabled .Values.metrics.enabled }}`}}"))
 			Expect(networkPolicy.TemplateBody).To(ContainSubstring("kind: NetworkPolicy"))
 			Expect(networkPolicy.TemplateBody).To(ContainSubstring(
 				`name: {{ "{{ include \"test-project.resourceName\" ` +
@@ -118,7 +119,8 @@ var _ = Describe("NetworkPolicy", func() {
 			Expect(err).NotTo(HaveOccurred())
 			webhookPolicy := string(content)
 
-			Expect(metricsPolicy).To(ContainSubstring("{{- if .Values.networkPolicy.enabled }}"))
+			Expect(metricsPolicy).To(ContainSubstring(
+				"{{- if and .Values.networkPolicy.enabled .Values.metrics.enabled }}"))
 			Expect(metricsPolicy).To(ContainSubstring(`{{ include "test-project.name" . }}`))
 			Expect(metricsPolicy).To(ContainSubstring(
 				`name: {{ include "test-project.resourceName" (dict "suffix" "allow-metrics-traffic" "context" $) }}`))

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/servicemonitor.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/servicemonitor.go
@@ -53,7 +53,13 @@ func (f *ServiceMonitor) SetTemplateDefaults() error {
 	chartName := f.ProjectName
 	f.TemplateBody = fmt.Sprintf(serviceMonitorTemplate, chartName, chartName, chartName, chartName)
 
-	f.IfExistsAction = machinery.OverwriteFile
+	// User-owned file: preserve local edits on regeneration unless --force is set,
+	// mirroring the NetworkPolicy templates.
+	if f.Force {
+		f.IfExistsAction = machinery.OverwriteFile
+	} else {
+		f.IfExistsAction = machinery.SkipFile
+	}
 
 	return nil
 }

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/servicemonitor_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/servicemonitor_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package charttemplates
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
+)
+
+var _ = Describe("ServiceMonitor", func() {
+	Context("SetTemplateDefaults", func() {
+		var serviceMonitor *ServiceMonitor
+
+		BeforeEach(func() {
+			serviceMonitor = &ServiceMonitor{
+				OutputDir:   helmChartOutputDir,
+				ServiceName: "test-project-controller-manager-metrics-service",
+			}
+			serviceMonitor.InjectProjectName("test-project")
+		})
+
+		It("preserves an existing file (SkipFile) when Force is false", func() {
+			serviceMonitor.Force = false
+			Expect(serviceMonitor.SetTemplateDefaults()).To(Succeed())
+			Expect(serviceMonitor.IfExistsAction).To(Equal(machinery.SkipFile))
+		})
+
+		It("overwrites (OverwriteFile) when Force is true", func() {
+			serviceMonitor.Force = true
+			Expect(serviceMonitor.SetTemplateDefaults()).To(Succeed())
+			Expect(serviceMonitor.IfExistsAction).To(Equal(machinery.OverwriteFile))
+		})
+	})
+})

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/test/chart_generation_integration_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/test/chart_generation_integration_test.go
@@ -585,6 +585,101 @@ var _ = Describe("Chart Generation Integration Tests", func() {
 		})
 	})
 
+	Context("NetworkPolicy (rendered)", func() {
+		// networkPolicyDoc returns the NetworkPolicy document whose name ends with the given
+		// suffix from a multi-document render, or "" when it was not rendered.
+		networkPolicyDoc := func(rendered, suffix string) string {
+			for _, doc := range strings.Split(rendered, "\n---") {
+				if strings.Contains(doc, "\nkind: NetworkPolicy\n") && strings.Contains(doc, suffix) {
+					return doc
+				}
+			}
+			return ""
+		}
+
+		renderWithNetworkPolicies := func(setArgs ...string) string {
+			out, err := helmTemplate(createKustomizeWithWebhooks("test-project"), setArgs...)
+			Expect(err).NotTo(HaveOccurred(), "helm template failed: %s", out)
+			return out
+		}
+
+		It("renders both policies with the metrics and webhook ports when enabled", func() {
+			rendered := renderWithNetworkPolicies(
+				"--set", "networkPolicy.enabled=true",
+				"--set", "metrics.enabled=true",
+				"--set", "webhook.enabled=true",
+			)
+
+			metricsPolicy := networkPolicyDoc(rendered, "allow-metrics-traffic")
+			Expect(metricsPolicy).NotTo(BeEmpty(), "metrics NetworkPolicy should be rendered")
+			Expect(metricsPolicy).To(ContainSubstring("metrics: enabled"))
+			Expect(metricsPolicy).To(ContainSubstring("port: 8443"))
+
+			webhookPolicy := networkPolicyDoc(rendered, "allow-webhook-traffic")
+			Expect(webhookPolicy).NotTo(BeEmpty(), "webhook NetworkPolicy should be rendered")
+			Expect(webhookPolicy).To(ContainSubstring("webhook: enabled"))
+			Expect(webhookPolicy).To(ContainSubstring("port: 9443"))
+		})
+
+		It("renders no NetworkPolicy when networkPolicy.enabled is false", func() {
+			rendered := renderWithNetworkPolicies(
+				"--set", "networkPolicy.enabled=false",
+				"--set", "metrics.enabled=true",
+				"--set", "webhook.enabled=true",
+			)
+
+			Expect(rendered).NotTo(ContainSubstring("kind: NetworkPolicy"))
+		})
+
+		It("suppresses the metrics policy when metrics are disabled but keeps the webhook policy", func() {
+			rendered := renderWithNetworkPolicies(
+				"--set", "networkPolicy.enabled=true",
+				"--set", "metrics.enabled=false",
+				"--set", "webhook.enabled=true",
+			)
+
+			Expect(networkPolicyDoc(rendered, "allow-metrics-traffic")).To(BeEmpty(),
+				"metrics NetworkPolicy must be gated by metrics.enabled")
+			Expect(networkPolicyDoc(rendered, "allow-webhook-traffic")).NotTo(BeEmpty(),
+				"webhook NetworkPolicy should still render")
+		})
+
+		It("suppresses the webhook policy when webhooks are disabled but keeps the metrics policy", func() {
+			rendered := renderWithNetworkPolicies(
+				"--set", "networkPolicy.enabled=true",
+				"--set", "metrics.enabled=true",
+				"--set", "webhook.enabled=false",
+			)
+
+			Expect(networkPolicyDoc(rendered, "allow-webhook-traffic")).To(BeEmpty(),
+				"webhook NetworkPolicy must be gated by webhook.enabled")
+			Expect(networkPolicyDoc(rendered, "allow-metrics-traffic")).NotTo(BeEmpty(),
+				"metrics NetworkPolicy should still render")
+		})
+
+		It("renders no NetworkPolicy when networkPolicy is enabled but metrics and webhooks are disabled", func() {
+			rendered := renderWithNetworkPolicies(
+				"--set", "networkPolicy.enabled=true",
+				"--set", "metrics.enabled=false",
+				"--set", "webhook.enabled=false",
+			)
+
+			Expect(rendered).NotTo(ContainSubstring("kind: NetworkPolicy"),
+				"both policies must be gated off when their features are disabled")
+		})
+
+		It("tracks custom metrics and webhook ports in the rendered policies", func() {
+			rendered := renderWithNetworkPolicies(
+				"--set", "networkPolicy.enabled=true",
+				"--set", "metrics.enabled=true", "--set", "metrics.port=9000",
+				"--set", "webhook.enabled=true", "--set", "webhook.port=9001",
+			)
+
+			Expect(networkPolicyDoc(rendered, "allow-metrics-traffic")).To(ContainSubstring("port: 9000"))
+			Expect(networkPolicyDoc(rendered, "allow-webhook-traffic")).To(ContainSubstring("port: 9001"))
+		})
+	})
+
 	Context("Custom Output Directory", func() {
 		It("should support custom output directory via --output-dir flag", func() {
 			kustomizeYAML := createBasicKustomizeOutput("test-project")

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/test/chart_never_overwrite_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/test/chart_never_overwrite_test.go
@@ -152,6 +152,46 @@ maintainers:
 		Expect(string(content)).To(ContainSubstring("My custom description"))
 	})
 
+	It("should preserve user edits to NetworkPolicy and ServiceMonitor unless --force", func() {
+		networkPolicyPath := filepath.Join(tmpDir, outputDir, "chart", "templates",
+			"network-policy", "allow-metrics-traffic.yaml")
+		serviceMonitorPath := filepath.Join(tmpDir, outputDir, "chart", "templates",
+			"prometheus", "controller-manager-metrics-monitor.yaml")
+
+		scaffoldChart := func(force bool) {
+			s := scaffolds.NewChartScaffolder(projectConfig, force, manifestsFile, outputDir)
+			s.InjectFS(fs)
+			Expect(s.Scaffold()).To(Succeed())
+		}
+
+		// Initial scaffold creates the user-owned files.
+		scaffoldChart(false)
+		Expect(os.WriteFile(networkPolicyPath, []byte("custom-network-policy\n"), 0o644)).To(Succeed())
+		Expect(os.WriteFile(serviceMonitorPath, []byte("custom-service-monitor\n"), 0o644)).To(Succeed())
+
+		// Regenerating without --force must keep the local edits.
+		scaffoldChart(false)
+		networkPolicyContent, err := os.ReadFile(networkPolicyPath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(networkPolicyContent)).To(Equal("custom-network-policy\n"),
+			"NetworkPolicy should be preserved without --force")
+		serviceMonitorContent, err := os.ReadFile(serviceMonitorPath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(serviceMonitorContent)).To(Equal("custom-service-monitor\n"),
+			"ServiceMonitor should be preserved without --force")
+
+		// Regenerating with --force must overwrite them.
+		scaffoldChart(true)
+		networkPolicyContent, err = os.ReadFile(networkPolicyPath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(networkPolicyContent)).To(ContainSubstring("kind: NetworkPolicy"),
+			"NetworkPolicy should be regenerated with --force")
+		serviceMonitorContent, err = os.ReadFile(serviceMonitorPath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(serviceMonitorContent)).To(ContainSubstring("kind: ServiceMonitor"),
+			"ServiceMonitor should be regenerated with --force")
+	})
+
 	It("should preserve Chart.yaml on initial scaffold if file already exists", func() {
 		// Create Chart.yaml before any scaffolding
 		chartPath := filepath.Join(tmpDir, outputDir, "chart", "Chart.yaml")

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/test/extras_integration_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/test/extras_integration_test.go
@@ -142,7 +142,7 @@ data:
 			Expect(resources.Other).To(HaveLen(2))
 
 			By("converting to Helm chart")
-			converter := kustomize.NewChartConverter(resources, "test-project", "test-project", "test-project-system", "dist", make(map[string]string))
+			converter := kustomize.NewChartConverter(resources, "test-project", "test-project", "test-project-system", "dist", make(map[string]string), false)
 			builders := converter.GetChartBuilders()
 			scaffold := machinery.NewScaffold(fs)
 			err = scaffold.Execute(builders...)
@@ -261,7 +261,7 @@ spec:
 			resources, err := parser.Parse()
 			Expect(err).NotTo(HaveOccurred())
 
-			converter := kustomize.NewChartConverter(resources, "test-project", "test-project", "test-project-system", "dist", make(map[string]string))
+			converter := kustomize.NewChartConverter(resources, "test-project", "test-project", "test-project-system", "dist", make(map[string]string), false)
 			builders := converter.GetChartBuilders()
 			scaffold := machinery.NewScaffold(fs)
 			err = scaffold.Execute(builders...)
@@ -325,7 +325,7 @@ spec:
 			resources, err := parser.Parse()
 			Expect(err).NotTo(HaveOccurred())
 
-			converter := kustomize.NewChartConverter(resources, "test-project", "test-project", "test-project-system", "dist", make(map[string]string))
+			converter := kustomize.NewChartConverter(resources, "test-project", "test-project", "test-project-system", "dist", make(map[string]string), false)
 			builders := converter.GetChartBuilders()
 			scaffold := machinery.NewScaffold(fs)
 			err = scaffold.Execute(builders...)
@@ -456,7 +456,7 @@ spec:
 			Expect(resources.RoleBindings).To(HaveLen(1), "should have 1 RoleBinding")
 			Expect(resources.Other).To(HaveLen(1), "ConfigMap should be in Other")
 
-			converter := kustomize.NewChartConverter(resources, "test-project", "test-project", "test-project-system", "dist", make(map[string]string))
+			converter := kustomize.NewChartConverter(resources, "test-project", "test-project", "test-project-system", "dist", make(map[string]string), false)
 			builders := converter.GetChartBuilders()
 			scaffold := machinery.NewScaffold(fs)
 			err = scaffold.Execute(builders...)
@@ -682,7 +682,7 @@ spec:
 			Expect(resources.RoleBindings).To(HaveLen(3), "should have 3 RoleBindings")
 
 			By("converting to Helm chart")
-			converter := kustomize.NewChartConverter(resources, "test-project", "test-project", "test-project-system", "dist", make(map[string]string))
+			converter := kustomize.NewChartConverter(resources, "test-project", "test-project", "test-project-system", "dist", make(map[string]string), false)
 			builders := converter.GetChartBuilders()
 			scaffold := machinery.NewScaffold(fs)
 			err = scaffold.Execute(builders...)
@@ -931,7 +931,7 @@ spec:
 			resources, err := parser.Parse()
 			Expect(err).NotTo(HaveOccurred())
 
-			converter := kustomize.NewChartConverter(resources, "test-project", "test-project", "test-project-system", "dist", make(map[string]string))
+			converter := kustomize.NewChartConverter(resources, "test-project", "test-project", "test-project-system", "dist", make(map[string]string), false)
 			builders := converter.GetChartBuilders()
 			scaffold := machinery.NewScaffold(fs)
 			err = scaffold.Execute(builders...)
@@ -1087,7 +1087,7 @@ spec:
 			resources, err := parser.Parse()
 			Expect(err).NotTo(HaveOccurred())
 
-			converter := kustomize.NewChartConverter(resources, "test-project", "test-project", "test-project-system", "dist", make(map[string]string))
+			converter := kustomize.NewChartConverter(resources, "test-project", "test-project", "test-project-system", "dist", make(map[string]string), false)
 			builders := converter.GetChartBuilders()
 			scaffold := machinery.NewScaffold(fs)
 			err = scaffold.Execute(builders...)
@@ -1235,7 +1235,7 @@ spec:
 			Expect(cr.GetAPIVersion()).To(Equal("batch.tutorial.kubebuilder.io/v1"))
 			Expect(cr.GetName()).To(Equal("cronjob-sample"))
 
-			converter := kustomize.NewChartConverter(resources, "test-project", "test-project", "test-project-system", "dist", make(map[string]string))
+			converter := kustomize.NewChartConverter(resources, "test-project", "test-project", "test-project-system", "dist", make(map[string]string), false)
 			builders := converter.GetChartBuilders()
 			scaffold := machinery.NewScaffold(fs)
 			err = scaffold.Execute(builders...)
@@ -1425,7 +1425,7 @@ spec:
 			Expect(roleNamespaces).To(HaveKey("manager-rolebinding-users"))
 
 			By("converting to Helm chart with role-namespace mappings")
-			chartConverter := kustomize.NewChartConverter(resources, namePrefix, "test-project", managerNamespace, "dist", roleNamespaces)
+			chartConverter := kustomize.NewChartConverter(resources, namePrefix, "test-project", managerNamespace, "dist", roleNamespaces, false)
 			builders := chartConverter.GetChartBuilders()
 			scaffold := machinery.NewScaffold(fs)
 			err = scaffold.Execute(builders...)

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/test/extras_integration_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/test/extras_integration_test.go
@@ -142,7 +142,7 @@ data:
 			Expect(resources.Other).To(HaveLen(2))
 
 			By("converting to Helm chart")
-			converter := kustomize.NewChartConverter(resources, "test-project", "test-project", "test-project-system", "dist", make(map[string]string), false)
+			converter := kustomize.NewChartConverter(resources, "test-project", "test-project", "test-project-system", "dist", make(map[string]string))
 			builders := converter.GetChartBuilders()
 			scaffold := machinery.NewScaffold(fs)
 			err = scaffold.Execute(builders...)
@@ -261,7 +261,7 @@ spec:
 			resources, err := parser.Parse()
 			Expect(err).NotTo(HaveOccurred())
 
-			converter := kustomize.NewChartConverter(resources, "test-project", "test-project", "test-project-system", "dist", make(map[string]string), false)
+			converter := kustomize.NewChartConverter(resources, "test-project", "test-project", "test-project-system", "dist", make(map[string]string))
 			builders := converter.GetChartBuilders()
 			scaffold := machinery.NewScaffold(fs)
 			err = scaffold.Execute(builders...)
@@ -325,7 +325,7 @@ spec:
 			resources, err := parser.Parse()
 			Expect(err).NotTo(HaveOccurred())
 
-			converter := kustomize.NewChartConverter(resources, "test-project", "test-project", "test-project-system", "dist", make(map[string]string), false)
+			converter := kustomize.NewChartConverter(resources, "test-project", "test-project", "test-project-system", "dist", make(map[string]string))
 			builders := converter.GetChartBuilders()
 			scaffold := machinery.NewScaffold(fs)
 			err = scaffold.Execute(builders...)
@@ -456,7 +456,7 @@ spec:
 			Expect(resources.RoleBindings).To(HaveLen(1), "should have 1 RoleBinding")
 			Expect(resources.Other).To(HaveLen(1), "ConfigMap should be in Other")
 
-			converter := kustomize.NewChartConverter(resources, "test-project", "test-project", "test-project-system", "dist", make(map[string]string), false)
+			converter := kustomize.NewChartConverter(resources, "test-project", "test-project", "test-project-system", "dist", make(map[string]string))
 			builders := converter.GetChartBuilders()
 			scaffold := machinery.NewScaffold(fs)
 			err = scaffold.Execute(builders...)
@@ -682,7 +682,7 @@ spec:
 			Expect(resources.RoleBindings).To(HaveLen(3), "should have 3 RoleBindings")
 
 			By("converting to Helm chart")
-			converter := kustomize.NewChartConverter(resources, "test-project", "test-project", "test-project-system", "dist", make(map[string]string), false)
+			converter := kustomize.NewChartConverter(resources, "test-project", "test-project", "test-project-system", "dist", make(map[string]string))
 			builders := converter.GetChartBuilders()
 			scaffold := machinery.NewScaffold(fs)
 			err = scaffold.Execute(builders...)
@@ -931,7 +931,7 @@ spec:
 			resources, err := parser.Parse()
 			Expect(err).NotTo(HaveOccurred())
 
-			converter := kustomize.NewChartConverter(resources, "test-project", "test-project", "test-project-system", "dist", make(map[string]string), false)
+			converter := kustomize.NewChartConverter(resources, "test-project", "test-project", "test-project-system", "dist", make(map[string]string))
 			builders := converter.GetChartBuilders()
 			scaffold := machinery.NewScaffold(fs)
 			err = scaffold.Execute(builders...)
@@ -1087,7 +1087,7 @@ spec:
 			resources, err := parser.Parse()
 			Expect(err).NotTo(HaveOccurred())
 
-			converter := kustomize.NewChartConverter(resources, "test-project", "test-project", "test-project-system", "dist", make(map[string]string), false)
+			converter := kustomize.NewChartConverter(resources, "test-project", "test-project", "test-project-system", "dist", make(map[string]string))
 			builders := converter.GetChartBuilders()
 			scaffold := machinery.NewScaffold(fs)
 			err = scaffold.Execute(builders...)
@@ -1235,7 +1235,7 @@ spec:
 			Expect(cr.GetAPIVersion()).To(Equal("batch.tutorial.kubebuilder.io/v1"))
 			Expect(cr.GetName()).To(Equal("cronjob-sample"))
 
-			converter := kustomize.NewChartConverter(resources, "test-project", "test-project", "test-project-system", "dist", make(map[string]string), false)
+			converter := kustomize.NewChartConverter(resources, "test-project", "test-project", "test-project-system", "dist", make(map[string]string))
 			builders := converter.GetChartBuilders()
 			scaffold := machinery.NewScaffold(fs)
 			err = scaffold.Execute(builders...)
@@ -1425,7 +1425,7 @@ spec:
 			Expect(roleNamespaces).To(HaveKey("manager-rolebinding-users"))
 
 			By("converting to Helm chart with role-namespace mappings")
-			chartConverter := kustomize.NewChartConverter(resources, namePrefix, "test-project", managerNamespace, "dist", roleNamespaces, false)
+			chartConverter := kustomize.NewChartConverter(resources, namePrefix, "test-project", managerNamespace, "dist", roleNamespaces)
 			builders := chartConverter.GetChartBuilders()
 			scaffold := machinery.NewScaffold(fs)
 			err = scaffold.Execute(builders...)

--- a/test/e2e/all/plugin_helm_test.go
+++ b/test/e2e/all/plugin_helm_test.go
@@ -205,6 +205,8 @@ var _ = Describe("kubebuilder", func() {
 				HasWebhook:          true,
 				HasMetrics:          true,
 				HasNetworkPolicies:  true,
+				MetricsPort:         customMetricsPort,
+				WebhookPort:         customWebhookPort,
 				InstallMethod:       helpers.InstallMethodHelm,
 				SkipChartGeneration: true, // Chart already generated and customized above
 			})

--- a/test/e2e/all/plugin_v4_test.go
+++ b/test/e2e/all/plugin_v4_test.go
@@ -106,7 +106,7 @@ var _ = Describe("kubebuilder", func() {
 		It("should generate a runnable project with a custom webhook port protected by network policies", func() {
 			helpers.GenerateV4WithNetworkPolicies(kbc)
 
-			By("configuring the manager and webhook Service to use a custom webhook port")
+			By("configuring the manager, webhook Service, and webhook NetworkPolicy to use a custom port")
 			const customWebhookPort = "9444"
 			Expect(util.ReplaceInFile(
 				filepath.Join(kbc.Dir, "config", "default", "manager_webhook_patch.yaml"),
@@ -114,12 +114,18 @@ var _ = Describe("kubebuilder", func() {
 			Expect(util.ReplaceInFile(
 				filepath.Join(kbc.Dir, "config", "webhook", "service.yaml"),
 				"targetPort: 9443", "targetPort: "+customWebhookPort)).To(Succeed())
+			// The webhook NetworkPolicy must allow the same pod port, otherwise a CNI that
+			// enforces NetworkPolicies would block admission traffic to the custom port.
+			Expect(util.ReplaceInFile(
+				filepath.Join(kbc.Dir, "config", "network-policy", "allow-webhook-traffic.yaml"),
+				"port: 9443", "port: "+customWebhookPort)).To(Succeed())
 
 			By("deploying with the custom webhook port and validating all webhook flows")
 			helpers.Run(kbc, helpers.RunOptions{
 				HasWebhook:         true,
 				HasMetrics:         true,
 				HasNetworkPolicies: true,
+				WebhookPort:        9444,
 				InstallMethod:      helpers.InstallMethodKustomize,
 			})
 

--- a/test/e2e/internal/helpers/plugin_test_helper.go
+++ b/test/e2e/internal/helpers/plugin_test_helper.go
@@ -63,6 +63,10 @@ type RunOptions struct {
 	HasMetrics bool
 	// HasNetworkPolicies indicates if network policies are enabled
 	HasNetworkPolicies bool
+	// MetricsPort is the expected metrics port the metrics NetworkPolicy must allow (defaults to 8443)
+	MetricsPort int
+	// WebhookPort is the expected webhook port the webhook NetworkPolicy must allow (defaults to 9443)
+	WebhookPort int
 	// IsNamespaced indicates if project is namespace-scoped
 	IsNamespaced bool
 	// InstallMethod specifies how to install the project
@@ -178,12 +182,21 @@ func Run(kbc *utils.TestContext, opts RunOptions) {
 	Expect(err).NotTo(HaveOccurred())
 
 	if opts.HasNetworkPolicies {
+		metricsPort := opts.MetricsPort
+		if metricsPort == 0 {
+			metricsPort = 8443
+		}
+		webhookPort := opts.WebhookPort
+		if webhookPort == 0 {
+			webhookPort = 9443
+		}
+
 		if opts.HasMetrics {
 			By("labeling the namespace to allow consume the metrics")
 			Expect(kbc.Kubectl.Command("label", "namespaces", kbc.Kubectl.Namespace,
 				"metrics=enabled")).Error().NotTo(HaveOccurred())
 
-			By("Ensuring the Allow Metrics Traffic NetworkPolicy exists", func() {
+			By("Ensuring the Allow Metrics Traffic NetworkPolicy exists and allows the metrics port", func() {
 				var output string
 				output, err = kbc.Kubectl.Get(
 					true,
@@ -192,6 +205,17 @@ func Run(kbc *utils.TestContext, opts RunOptions) {
 				Expect(err).NotTo(HaveOccurred(), "NetworkPolicy allow-metrics-traffic should exist in the namespace")
 				Expect(output).To(ContainSubstring("allow-metrics-traffic"), "NetworkPolicy allow-metrics-traffic "+
 					"should be present in the output")
+
+				// The NetworkPolicy must allow the pod's metrics port, otherwise it blocks scraping.
+				var port string
+				port, err = kbc.Kubectl.Get(
+					true,
+					"networkpolicy", fmt.Sprintf("e2e-%s-allow-metrics-traffic", kbc.TestSuffix),
+					"-o", "jsonpath={.spec.ingress[*].ports[*].port}",
+				)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(port).To(Equal(strconv.Itoa(metricsPort)),
+					"metrics NetworkPolicy must allow the metrics port")
 			})
 		}
 
@@ -201,7 +225,7 @@ func Run(kbc *utils.TestContext, opts RunOptions) {
 				"webhook=enabled")
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Ensuring the allow-webhook-traffic NetworkPolicy exists", func() {
+			By("Ensuring the allow-webhook-traffic NetworkPolicy exists and allows the webhook port", func() {
 				var output string
 				output, err = kbc.Kubectl.Get(
 					true,
@@ -210,6 +234,18 @@ func Run(kbc *utils.TestContext, opts RunOptions) {
 				Expect(err).NotTo(HaveOccurred(), "NetworkPolicy allow-webhook-traffic should exist in the namespace")
 				Expect(output).To(ContainSubstring("allow-webhook-traffic"), "NetworkPolicy allow-webhook-traffic "+
 					"should be present in the output")
+
+				// The webhook NetworkPolicy must allow the pod's webhook container port (9443),
+				// not the webhook Service port (443); the wrong port blocks admission traffic.
+				var port string
+				port, err = kbc.Kubectl.Get(
+					true,
+					"networkpolicy", fmt.Sprintf("e2e-%s-allow-webhook-traffic", kbc.TestSuffix),
+					"-o", "jsonpath={.spec.ingress[*].ports[*].port}",
+				)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(port).To(Equal(strconv.Itoa(webhookPort)),
+					"webhook NetworkPolicy must allow the webhook container port")
 			})
 		}
 	}

--- a/testdata/project-v4-multigroup/config/default/kustomization.yaml
+++ b/testdata/project-v4-multigroup/config/default/kustomization.yaml
@@ -29,7 +29,7 @@ resources:
 - metrics_service.yaml
 # [NETWORK POLICY] Protect the /metrics endpoint and Webhook Server with NetworkPolicy.
 # Only Pod(s) running a namespace labeled with 'metrics: enabled' will be able to gather the metrics.
-# Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhooks: enabled' will
+# Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhook: enabled' will
 # be able to communicate with the Webhook Server.
 #- ../network-policy
 

--- a/testdata/project-v4-multigroup/config/network-policy/allow-webhook-traffic.yaml
+++ b/testdata/project-v4-multigroup/config/network-policy/allow-webhook-traffic.yaml
@@ -23,5 +23,5 @@ spec:
           matchLabels:
             webhook: enabled # Only from namespaces with this label
       ports:
-        - port: 443
+        - port: 9443
           protocol: TCP

--- a/testdata/project-v4-with-plugins/config/default/kustomization.yaml
+++ b/testdata/project-v4-with-plugins/config/default/kustomization.yaml
@@ -29,7 +29,7 @@ resources:
 - metrics_service.yaml
 # [NETWORK POLICY] Protect the /metrics endpoint and Webhook Server with NetworkPolicy.
 # Only Pod(s) running a namespace labeled with 'metrics: enabled' will be able to gather the metrics.
-# Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhooks: enabled' will
+# Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhook: enabled' will
 # be able to communicate with the Webhook Server.
 #- ../network-policy
 

--- a/testdata/project-v4-with-plugins/config/network-policy/allow-webhook-traffic.yaml
+++ b/testdata/project-v4-with-plugins/config/network-policy/allow-webhook-traffic.yaml
@@ -23,5 +23,5 @@ spec:
           matchLabels:
             webhook: enabled # Only from namespaces with this label
       ports:
-        - port: 443
+        - port: 9443
           protocol: TCP

--- a/testdata/project-v4-with-plugins/dist/chart/templates/network-policy/allow-metrics-traffic.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/network-policy/allow-metrics-traffic.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.networkPolicy.enabled }}
+{{- if and .Values.networkPolicy.enabled .Values.metrics.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/testdata/project-v4/config/default/kustomization.yaml
+++ b/testdata/project-v4/config/default/kustomization.yaml
@@ -29,7 +29,7 @@ resources:
 - metrics_service.yaml
 # [NETWORK POLICY] Protect the /metrics endpoint and Webhook Server with NetworkPolicy.
 # Only Pod(s) running a namespace labeled with 'metrics: enabled' will be able to gather the metrics.
-# Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhooks: enabled' will
+# Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhook: enabled' will
 # be able to communicate with the Webhook Server.
 #- ../network-policy
 

--- a/testdata/project-v4/config/network-policy/allow-webhook-traffic.yaml
+++ b/testdata/project-v4/config/network-policy/allow-webhook-traffic.yaml
@@ -23,5 +23,5 @@ spec:
           matchLabels:
             webhook: enabled # Only from namespaces with this label
       ports:
-        - port: 443
+        - port: 9443
           protocol: TCP


### PR DESCRIPTION
Follow-up to kubernetes-sigs/kubebuilder#5905.

## What changed

- preserve the existing `NewChartConverter` signature and add `NewChartConverterWithForce` for the new overwrite behavior
- restore the exported `FeatureSet` NetworkPolicy fields and their detection behavior
- update internal call sites to use the compatible constructors

## Why

PR #5905 changed an exported constructor signature and removed two exported fields. The APIDiff workflow correctly classified those changes as incompatible and blocked Tide. This patch keeps the NetworkPolicy fixes while making the API changes additive.

## Validation

- `go-apidiff 4d78446e0074fa5cab4c9e86f98e43bfba0ad275 --compare-imports --print-compatible --repo-path=.`
- `make install`
- `make generate-charts`
- `make verify-helm`
- `make lint-fix`
- `make test-unit`